### PR TITLE
Fix PHP Deprecated: is_readable() in PHP 8.1

### DIFF
--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -57,6 +57,10 @@ class ConfigFactory
             try {
                 $file = array_pop($files);
 
+                if (! is_string($file)) {
+                    continue;
+                }
+                
                 if (! is_readable($file)) {
                     continue;
                 }


### PR DESCRIPTION
Fixes 'PHP Deprecated: is_readable(): Passing null to parameter #1 ($filename) of type string is deprecated' in PHP 8.1

Hope all is good :)